### PR TITLE
fix: filter out visuals without links

### DIFF
--- a/SoundcloudScript.js
+++ b/SoundcloudScript.js
@@ -585,7 +585,7 @@ function soundcloudUserToPlatformChannel(scu) {
         subscribers: scu.followers_count,
         description: scu.description,
         url: scu.permalink_url,
-        links: scu.visuals ? scu.visuals.visuals.map((v) => v.link) : [],
+        links: scu.visuals ? scu.visuals.visuals.filter((v) => v.link).map((v) => v.link) : [],
     })
 }
 


### PR DESCRIPTION
There is a small bug when converting a user to a PlatformChannel.
If a user has a banner image that is not a link (e.g. [himmel](https://soundcloud.com/himmeltengoku)), the list of links will be `[null]`, which trips up the grayjay serializer and causes the app to crash when you try to subscribe to such a channel.
This was originally reported here: futo-org/grayjay-android#1240

This PR just adds an extra filter to make sure only visuals that actually have a link are added. 